### PR TITLE
Fix. Can not used iam_instance_profile options when spot_instance is enabled

### DIFF
--- a/lib/vagrant-aws/action/run_instance.rb
+++ b/lib/vagrant-aws/action/run_instance.rb
@@ -223,6 +223,8 @@ module VagrantPlugins
             'LaunchSpecification.Placement.AvailabilityZone' => config.availability_zone,
             'LaunchSpecification.UserData'                   => config.user_data,
             'LaunchSpecification.SubnetId'                   => config.subnet_id,
+            'LaunchSpecification.IamInstanceProfile.Arn'     => config.iam_instance_profile_arn,
+            'LaunchSpecification.IamInstanceProfile.Name'    => config.iam_instance_profile_name,
             'ValidUntil'                                     => config.spot_valid_until
           }
           security_group_key = config.subnet_id.nil? ? 'LaunchSpecification.SecurityGroup' : 'LaunchSpecification.SecurityGroupId'


### PR DESCRIPTION
When I want to use both `spot_instance` and `iam_instance_profile_name`, but  `iam_instance_profile_name` is not sent.

# Vagrantfile
```ruby
Vagrant.configure(2) do |config|
  config.vm.provider :aws do |aws, override|
    aws.spot_instance = true
    aws.iam_instance_profile_name = "my_role"
  end
```

# vagrant log
There is `IAM Instance Profile Name` 

```sh
$ vagrant up --provider=aws
Bringing machine 'default' up with 'aws' provider...
==> default: Warning! The AWS provider doesn't support any of the Vagrant
==> default: high-level network configurations (`config.vm.network`). They
==> default: will be silently ignored.
==> default: Warning! You're launching this instance into a VPC without an
==> default: elastic IP. Please verify you're properly connected to a VPN so
==> default: you can access this machine, otherwise Vagrant will not be able
==> default: to SSH into it.
==> default: Launching an instance with the following settings...
==> default:  -- Type: c3.large
==> default:  -- AMI: ami-20f8ef4e
==> default:  -- Region: ap-northeast-1
==> default:  -- Availability Zone: ap-northeast-1c
==> default:  -- Keypair: sue445
==> default:  -- Subnet ID: xxxxxxxx
==> default:  -- IAM Instance Profile Name: my_role
==> default:  -- User Data: yes
==> default:  -- Security Groups: ["sg-xxxxxxxx", "sg-xxxxxxxx"]
```

# Console
But IAM role is empty!
![image](https://cloud.githubusercontent.com/assets/608755/14166512/2128018c-f74f-11e5-9ffb-c55c91a72d41.png)
